### PR TITLE
Surround IDs with double quotes by default and back quotes for MySQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ Thumbs.db
 
 #OSX .DS_Store files
 .DS_Store
+
+# ignore IntelliJ IDEA project files
+/.idea
+*.iml

--- a/DDLGenerator.js
+++ b/DDLGenerator.js
@@ -76,7 +76,8 @@ define(function (require, exports, module) {
      */
     DDLGenerator.prototype.getId = function (id, options) {
         if (options.quoteIdentifiers) {
-            return "`" + id + "`";
+            var quote = options.dbms === "mysql" ? "`" : "\"";
+            return quote + id + quote;
         }
         return id;
     };

--- a/README.md
+++ b/README.md
@@ -66,8 +66,18 @@ CREATE TABLE entity1 (
 ALTER TABLE entity1 ADD FOREIGN KEY (fk1) REFERENCES entity2(col1);
 ```
 
-* If `Quote Identifiers` option is selected, all identifiers will be surrounded by a backquote character.
+* If `Quote Identifiers` option is selected, all identifiers will be surrounded by double quotes (or backquotes for MySQL).
 
+(__Oracle__ selected in `DBMS` option)
+```sql
+CREATE TABLE "entity1" (
+    "col1" INTEGER,
+    "col2" VARCHAR(20),
+    ...
+);
+```
+
+(__MySQL__ selected in `DBMS` option)
 ```sql
 CREATE TABLE `entity1` (
     `col1` INTEGER,


### PR DESCRIPTION
Currently delimited identifiers are quoted with back quotes. Back quotes, however, are only supported by MySQL. The SQL-99 standard defines [double quotes for delimited identifiers](http://savage.net.au/SQL/sql-99.bnf.html#delimited%20identifier) which other DBMSs like Oracle support. This pull request will use double quotes unless the DBMS is MySQL.
