### PR TITLE
Added support for comments and MySQL engine selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ CREATE TABLE entity1 (...);
 ...
 ```
 
+* If `Generate Comments` option is selected, COMMENT statements will be included, both in columns and tables.
+```sql
+CREATE TABLE `entity1` (
+    `col1` INTEGER COMMENT 'Comment 1',
+    `col2` VARCHAR(20) COMMENT 'Comment 2',
+    ...
+) COMMENT='Table comment';
+```
+
+* If using MySQL, the selected engine will be added to every CREATE TABLE statement.
+```sql
+CREATE TABLE `entity1` (
+    `col1` INTEGER,
+    `col2` VARCHAR(20),
+    ...
+) ENGINE=InnoDB;
+```
+
 
 Contributions
 -------------

--- a/ddl-generator.js
+++ b/ddl-generator.js
@@ -119,6 +119,9 @@ class DDLGenerator {
     if (elem.primaryKey || !elem.nullable) {
       line += ' NOT NULL'
     }
+	if (options.generateComments && elem.documentation !== '') {
+		line += ' COMMENT \'' + elem.documentation + '\''
+	}
     return line
   }
 
@@ -197,6 +200,7 @@ class DDLGenerator {
     var lines = []
     var primaryKeys = []
     var uniques = []
+	var line = ''
 
     // Table
     codeWriter.writeLine('CREATE TABLE ' + self.getId(elem.name, options) + ' (')
@@ -229,7 +233,16 @@ class DDLGenerator {
     }
 
     codeWriter.outdent()
-    codeWriter.writeLine(');')
+	line = ')'
+	if (options.dbms === 'mysql') {
+		line += ' ENGINE=' + options.mySqlEngine
+	}
+	if (options.generateComments && elem.documentation !== '') {
+		line += ' COMMENT=\'' + elem.documentation + '\''
+	}
+	line += ';'
+	
+	codeWriter.writeLine(line)
     codeWriter.writeLine()
   }
 

--- a/main.js
+++ b/main.js
@@ -30,7 +30,9 @@ function getGenOptions () {
     dropTable: app.preferences.get('ddl.gen.dropTable'),
     dbms: app.preferences.get('ddl.gen.dbms'),
     useTab: app.preferences.get('ddl.gen.useTab'),
-    indentSpaces: app.preferences.get('ddl.gen.indentSpaces')
+    indentSpaces: app.preferences.get('ddl.gen.indentSpaces'),
+	generateComments: app.preferences.get('ddl.gen.generateComments'),
+	mySqlEngine: app.preferences.get('ddl.gen.mysqlEngine')
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "https://github.com/niklauslee/staruml-ddl",
   "issues": "https://github.com/niklauslee/staruml-ddl/issues",
   "keywords": ["ddl", "erd", "database"],
-  "version": "0.9.2",
+  "version": "0.9.3",
   "author": {
     "name": "Minkyu Lee",
     "email": "niklaus.lee@gmail.com",

--- a/preferences/preference.json
+++ b/preferences/preference.json
@@ -49,6 +49,22 @@
       "description": "Number of spaces for indentation.",
       "type": "number",
       "default": 4
+    },
+    "ddl.gen.generateComments": {
+      "text": "Generate Comments",
+      "description": "Generate Comments",
+      "type": "check",
+      "default": true
+    },
+    "ddl.gen.mysqlEngine": {
+      "text": "MySQL Engine",
+      "description": "Select the MySQL Engine to use for each generated table",
+      "type": "dropdown",
+      "options": [
+        { "value": "InnoDB",  "text": "InnoDB" },
+        { "value": "MyISAM", "text": "MyISAM " }
+      ],
+      "default": "InnoDB"
     }
   }
 }


### PR DESCRIPTION
I was using this extension for generating the DDL for one of my projects, but I missed the functionality to include the documentation as comments in the generated SQL, as well as choosing the MySQL engine, so I added it :)

Let me know if you find it useful ;)